### PR TITLE
feat: Add common link hover style and fix build

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-noto-sans-jp), sans-serif;
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -118,5 +118,8 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+  a {
+    @apply text-primary hover:underline;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,9 +19,6 @@ const config = {
       },
     },
     extend: {
-      fontFamily: {
-        sans: ['var(--font-noto-sans-jp)', ...fontFamily.sans],
-      },
       keyframes: {
         'accordion-down': {
           from: { height: '0' },


### PR DESCRIPTION
This commit introduces a common hover style for all links. A global style is added to `globals.css` to make all `<a>` tags use the primary color and have an underline on hover.

Additionally, this commit fixes a build issue related to the font configuration in Tailwind CSS v4. The font family definition was moved from `tailwind.config.ts` to `globals.css` to align with v4 practices and resolve the build error.